### PR TITLE
Fix empty duplicated file when saving with Firefox

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ const cursedFilenameRegex = /(image|video)+\d/;
 
 const watchedPaths = process.env.DISCORD_WATCHED_PATHS.split(',').map(s => s.trim());
 
+function sleep(time) {
+  return new Promise(resolve => setTimeout(resolve, time));
+}
+
 chokidar.watch(watchedPaths, {
   ignoreInitial: true,
   depth: 0
@@ -22,6 +26,9 @@ chokidar.watch(watchedPaths, {
 
   if (cursedFilenameRegex.test(pathData.name)) {
     console.log(`Cursed filename found at ${filePath}, renaming to ${newPath}`);
+
+    // We wait some extra time because it seems firefox does some shenanigans with the file
+    await sleep(150);
 
     try {
       backOff(() => fs.rename(filePath, newPath));


### PR DESCRIPTION
This is an attempt to fix the empty unrenamed file leftover when firefox does it's thing.